### PR TITLE
Added Pod-monitor for Kratos

### DIFF
--- a/helm/kratos-operator/templates/_helpers.tpl
+++ b/helm/kratos-operator/templates/_helpers.tpl
@@ -47,6 +47,14 @@ heritage: {{ $.Release.Service | quote }}
 {{- end }}
 {{- end }}
 
+{{/* Generate promethues labels */}}
+{{- define "kratos-operator.prometheusLabels" }}
+{{ include "kratos-operator.labels" . }}
+{{- if .Values.prometheus.labels}}
+{{ toYaml .Values.prometheus.labels }}
+{{- end }}
+{{- end }}
+
 {{/*
 Allow the release namespace to be overridden for multi-namespace deployments in combined charts
 */}}

--- a/helm/kratos-operator/templates/podmonitor.yaml
+++ b/helm/kratos-operator/templates/podmonitor.yaml
@@ -1,0 +1,22 @@
+{{- if eq .Values.prometheus.podmonitor true -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kratos-operator.podmonitor
+  namespace: {{ template "kratos-operator.namespace" . }}
+  labels:
+{{ include "kratos-operator.prometheusLabels" . | indent 4 }}
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    port: {{ .Values.prometheus.port }}
+    path: {{ .Values.prometheus.path }}
+    metricRelabelings: {}
+    relabelings: {}
+  namespaceSelector:
+    matchNames:
+      - {{ template "kratos-operator.namespace" . }}
+  selector:
+    matchLabels:
+      app: {{ template "kratos-operator.name" . }}
+{{ end }}

--- a/helm/kratos-operator/templates/podmonitor.yaml
+++ b/helm/kratos-operator/templates/podmonitor.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   podMetricsEndpoints:
   - interval: 30s
-    port: {{ .Values.prometheus.port }}
+    port: {{ .Values.commandLineArgs.metrics-addr | trimPrefix ":" }}
     path: {{ .Values.prometheus.path }}
     metricRelabelings: {}
     relabelings: {}

--- a/helm/kratos-operator/templates/podmonitor.yaml
+++ b/helm/kratos-operator/templates/podmonitor.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   podMetricsEndpoints:
   - interval: 30s
-    port: {{ .Values.commandLineArgs.metrics-addr | trimPrefix ":" }}
+    port: {{ index .Values.commandLineArgs "metrics-addr" | trimPrefix ":" | int }}
     path: {{ .Values.prometheus.path }}
     metricRelabelings: {}
     relabelings: {}

--- a/helm/kratos-operator/values.yaml
+++ b/helm/kratos-operator/values.yaml
@@ -17,6 +17,16 @@ image:
   repository: adobe/kratos
   tag: v0.0.1
 
+prometheus:
+  path: /metrics
+  port: 8080
+  # Whether to use a podmonitor or not.
+  podmonitor: true
+  labels:
+    app: prometheus-operator
+    release: prometheus
+
+
 commandLineArgs:
   metrics-addr: ":8080"
   namespaces: ""

--- a/helm/kratos-operator/values.yaml
+++ b/helm/kratos-operator/values.yaml
@@ -19,7 +19,6 @@ image:
 
 prometheus:
   path: /metrics
-  port: 8080
   # Whether to use a podmonitor or not.
   podmonitor: true
   labels:


### PR DESCRIPTION
Add Pod-monitor for monitoring Kratos pods with Prometheus.

## Description

Add Pod-monitor for monitoring Kratos pods with Prometheus.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
